### PR TITLE
Fix test for python3

### DIFF
--- a/test/MockTest.py
+++ b/test/MockTest.py
@@ -85,7 +85,7 @@ print( "checking STOMP mock" )
 @CMock.Mock( lib.g, lib, method=CMock.STOMP )
 def mockedG( i, s ):
    print( "this is the mocked g %d/%s" % ( i, s ) )
-   assert( s == "forty-two" and i == 42 )
+   assert( s == b"forty-two" and i == 42 )
    return 99
 
 lib.entry_g(99)


### PR DESCRIPTION
Need to use explicit b'' prefix on string to make it work for py3.